### PR TITLE
Fix command display in power management section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -39,8 +39,8 @@ To enable management of the device TDP, switch to desktop mode and then install 
 
 | Source | Installation URL |
 | -- | -- |
-| [Decky Loader](https://github.com/SteamDeckHomebrew/decky-loader) | ```curl -L https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/install_release.sh \| sh``` |
-| [Simple Decky TDP](https://github.com/SteamFork/SimpleDeckyTDP) | ```curl -L https://github.com/SteamFork/SimpleDeckyTDP/raw/main/install.sh \| sh``` |
+| [Decky Loader](https://github.com/SteamDeckHomebrew/decky-loader) | <code>curl -L https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/install_release.sh \| sh</code> |
+| [Simple Decky TDP](https://github.com/SteamFork/SimpleDeckyTDP) | <code>curl -L https://github.com/SteamFork/SimpleDeckyTDP/raw/main/install.sh \| sh</code> |
 
 ## Credits
 


### PR DESCRIPTION
Discover there is one extra `\` in the install command while i am setting up my machine

| Before | After |
| --- | --- |
|![Screenshot_2024-06-20_22-04-13](https://github.com/SteamFork/wiki/assets/446404/3c649cdb-0720-481a-be6c-f5837212dfe4) | ![Screenshot_2024-06-20_22-04-00](https://github.com/SteamFork/wiki/assets/446404/6a789426-489a-4504-8b13-6b33ed969635) | 

