### PR TITLE
Drop sponsorship for Win600 and Claw.  Restore Community Verified wiki pages.

### DIFF
--- a/docs/devices/anbernic/win600.md
+++ b/docs/devices/anbernic/win600.md
@@ -10,6 +10,10 @@ title: Anbernic Win600
 
 ![](../../_inc/images/devices/anbernic-win600.png){ .off-glb }
 
+!!! warning
+    This device is currently unsponsored.
+    Information may be out of date or incorrect.
+
 ## Features
 
 | Feature | Notes |

--- a/docs/devices/antec/core-hs.md
+++ b/docs/devices/antec/core-hs.md
@@ -1,0 +1,60 @@
+title: Antec Core HS
+
+<style>
+  code {white-space: nowrap;}
+  kbd {white-space: nowrap;}
+  no-wrap {white-space: nowrap;}
+</style>
+
+# Antec Core HS
+
+![](../../_inc/images/devices/ayaneo-slide.png){ .off-glb }
+
+!!! warning
+    This device is currently unsponsored.
+    Information may be out of date or incorrect.
+
+!!!info
+    New AMD 7000 series devices do not support S3 sleep and must be configured for Modern Standby + s0i3.
+    Follow the [process on the Wiki](https://wiki.steamfork.org/troubleshooting/#enabling-modern-sleep-on-7000-series-amd-based-devices) to configure your device.
+
+## Features
+
+| Feature | Notes |
+| -- | -- |
+| <no-wrap>:material-harddisk: Storage</no-wrap> | SteamFork can be run from a USB Drive or installed directly to the internal NVME. 
+| <no-wrap>:material-wifi: Wifi</no-wrap> | Can be turned on in Steam OS under `Main Menu` > `Network Settings`. |
+| <no-wrap>:simple-bluetooth: Bluetooth</no-wrap> | Supports bluetooth audio and controllers. |
+| <no-wrap>:material-fan: Fan</no-wrap> | Controlled by system firmware. |
+| <no-wrap>:material-lightning-bolt-circle: TDP Limit</no-wrap> | Can be set globally, per system or per game. Requires the [SimpleDeckyTDP](https://github.com/SteamFork/SimpleDeckyTDP) plugin.|
+| <no-wrap>:material-vibrate: Rumble</no-wrap> | Enables the device rumble motor in emulators that support it. |
+| <no-wrap>:material-lightbulb-on: RGB</no-wrap> | Disabled on startup. Requires the [HueSync](https://github.com/honjow/HueSync) plugin for additional RGB control.|
+
+### Function Buttons
+
+| Button | Function |
+| -- | -- |
+| ++"Aya"++ | <kbd>:material-microsoft-xbox: Guide</kbd> <no-wrap>(`Steam Menu`)</no-wrap> |
+| <kbd>:material-equal:</kbd> | <no-wrap><kbd>:material-microsoft-xbox: Guide</kbd> + <kbd>:material-gamepad-circle-down: A</kbd></no-wrap> <no-wrap>(`Quick Access Menu`)</no-wrap> |
+| ++"LC"++ | ++"L4"++ |
+| ++"RC"++ | ++"R4"++ |
+
+## Notes
+
+### Installation
+
+Download the latest `AMD64` version of SteamFork from the button below and follow the instructions listed on the [Install](../../../play/install/) page.
+
+[![Latest Version](https://img.shields.io/github/release/SteamFork/distribution.svg?labelColor=111111&color=5998FF&label=Latest&style=flat#only-light)](https://github.com/SteamFork/distribution/releases/latest)
+[![Latest Version](https://img.shields.io/github/release/SteamFork/distribution.svg?labelColor=dddddd&color=5998FF&label=Latest&style=flat#only-dark)](https://github.com/SteamFork/distribution/releases/latest)
+
+### Known Issues
+
+* An unknown issue exists that causes the device to reboot unexpectedly.  There is no notification or panic log.
+* When Modern Standby is enabled, the power button does not send events to the OS.  Sleep works with Modern Standby + Si02 when selected from the Steam interface.
+
+### Booting from an external drive (USB or SD Card)
+
+To boot SteamFork from an external drive, hold <no-wrap>++"LC"++ + <kbd>:material-plus: Volume Up</kbd></no-wrap> and press <kbd>:material-power: Power</kbd> ,
+continue holding <no-wrap>++"LC"++ + <kbd>:material-plus: Volume Up</kbd></no-wrap> until the Ayaneo logo appears.
+Select the storage device with SteamFork from the boot menu using the ++"Ayaneo"++ button, and then press <kbd>:material-plus: Volume Up</kbd> to boot the distribution.

--- a/docs/devices/atari/vcs.md
+++ b/docs/devices/atari/vcs.md
@@ -1,0 +1,35 @@
+title: Atari VCS
+
+<style>
+  code {white-space: nowrap;}
+  kbd {white-space: nowrap;}
+  no-wrap {white-space: nowrap;}
+</style>
+
+# Atari VCS
+
+![](../../_inc/images/devices/atari-vcs.png){ .off-glb }
+
+!!! warning
+    This device is currently unsponsored.
+    Information may be out of date or incorrect.
+
+## Features
+
+| Feature | Notes |
+| -- | -- |
+| <no-wrap>:material-harddisk: Storage</no-wrap> | SteamFork can be run from an USB Drive or installed directly to the internal drive.
+| <no-wrap>:material-wifi: Wifi</no-wrap> | Can be turned on in Steam OS under `Main Menu` > `Network Settings` |
+| <no-wrap>:simple-bluetooth: Bluetooth</no-wrap> | Supports bluetooth audio and controllers |
+| <no-wrap>:material-fan: Fan</no-wrap> | Controlled by system firmware. |
+| <no-wrap>:material-lightning-bolt-circle: TDP Limit</no-wrap> | Can be set globally, per system or per game. Requires the [SimpleDeckyTDP](https://github.com/SteamFork/SimpleDeckyTDP) plugin.|
+| <no-wrap>:material-vibrate: Rumble</no-wrap> | Enables the device rumble motor in emulators using controllers that support it. |
+
+## Notes
+
+### Installation
+
+Download the latest `AMD64` version of SteamFork from the button below and follow the instructions listed on the [Install](../../../play/install/) page.
+
+[![Latest Version](https://img.shields.io/github/release/SteamFork/distribution.svg?labelColor=111111&color=5998FF&label=Latest&style=flat#only-light)](https://github.com/SteamFork/distribution/releases/latest)
+[![Latest Version](https://img.shields.io/github/release/SteamFork/distribution.svg?labelColor=dddddd&color=5998FF&label=Latest&style=flat#only-dark)](https://github.com/SteamFork/distribution/releases/latest)

--- a/docs/devices/ayaneo/air.md
+++ b/docs/devices/ayaneo/air.md
@@ -1,0 +1,80 @@
+title: AYANEO Air / Air Pro
+
+<style>
+  code {white-space: nowrap;}
+  kbd {white-space: nowrap;}
+  no-wrap {white-space: nowrap;}
+</style>
+
+# AYANEO Air / Air Pro
+
+![](../../_inc/images/devices/ayaneo-air.png){ .off-glb }
+
+!!! warning
+    This device is currently unsponsored.
+    Information may be out of date or incorrect.
+
+## Features
+
+| Feature | Notes |
+| -- | -- |
+| <no-wrap>:material-harddisk: Storage</no-wrap> | SteamFork can be run from an SD Card, USB Drive or installed directly to the internal NVME. 
+| <no-wrap>:material-wifi: Wifi</no-wrap> | Can be turned on in Steam OS under `Main Menu` > `Network Settings`. |
+| <no-wrap>:simple-bluetooth: Bluetooth</no-wrap> | Supports bluetooth audio and controllers. |
+| <no-wrap>:material-fan: Fan</no-wrap> | Managed automatically. |
+| <no-wrap>:material-lightning-bolt-circle: TDP Limit</no-wrap> | Can be set globally, per system or per game. Requires the [SimpleDeckyTDP](https://github.com/SteamFork/SimpleDeckyTDP) plugin.|
+| <no-wrap>:material-vibrate: Rumble</no-wrap> | Enables the device rumble motor in emulators that support it. |
+| <no-wrap>:material-lightbulb-on: RGB</no-wrap> | Disabled on startup. Requires the [HueSync](https://github.com/honjow/HueSync) plugin for additional RGB control.|
+
+### Function Buttons
+
+| Button | Function |
+| -- | -- |
+| ++"Aya"++ | <kbd>:material-microsoft-xbox: Guide</kbd> <no-wrap>(`Steam Menu`)</no-wrap> |
+| <kbd>:material-equal:</kbd> | <no-wrap><kbd>:material-microsoft-xbox: Guide</kbd> + <kbd>:material-gamepad-circle-down: A</kbd></no-wrap> <no-wrap>(`Quick Access Menu`)</no-wrap> |
+| ++"LC"++ | ++"L4"++ |
+| ++"RC"++ | ++"R4"++ |
+
+## Notes
+
+### Installation
+
+Download the latest `AMD64` version of SteamFork from the button below and follow the instructions listed on the [Install](../../../play/install/) page.
+
+[![Latest Version](https://img.shields.io/github/release/SteamFork/distribution.svg?labelColor=111111&color=5998FF&label=Latest&style=flat#only-light)](https://github.com/SteamFork/distribution/releases/latest)
+[![Latest Version](https://img.shields.io/github/release/SteamFork/distribution.svg?labelColor=dddddd&color=5998FF&label=Latest&style=flat#only-dark)](https://github.com/SteamFork/distribution/releases/latest)
+
+### Booting from an external drive (USB or SD Card)
+
+To boot SteamFork from an external drive, hold <no-wrap>++"LC"++ + <kbd>:material-plus: Volume Up</kbd></no-wrap> and press <kbd>:material-power: Power</kbd> ,
+continue holding <no-wrap>++"LC"++ + <kbd>:material-plus: Volume Up</kbd></no-wrap> until the Ayaneo logo appears.
+Select the storage device with SteamFork from the boot menu using the ++"Ayaneo"++ button, and then press <kbd>:material-plus: Volume Up</kbd> to boot the distribution.
+
+### Fixing Audio Polarity
+Early Ayaneo Air and Air Pro models were shipped with speaker polarity reversed.  Correcting this condition is simple, it requires creating a custom quirk.  Custom quirks persist across updates.
+
+```
+### Set a variable to define your custom quirk, Ayaneo Air and Air Pro devices use `AYANEO-AIR`.
+export CUSTDIR="/home/.steamos/offload/customdevicequirks/AYANEO-AIR/boot.d"
+
+### Create the directory and change into it.
+sudo mkdir -p ${CUSTDIR}
+cd ${CUSTDIR}
+
+### Create the quirk
+cat <<EOF | sudo tee audio-phase-fix.sh
+#!/bin/sh
+master=alsa_output.pci-0000_04_00.6.analog-stereo
+pactl load-module module-ladspa-sink sink_name=ladspa_out sink_master=$master plugin=inv_1429 label=inv channel_map=front-right
+pactl load-module module-remap-sink sink_name=remap_FR master=ladspa_out channels=1 master_channel_map=front-right channel_map=front-right
+pactl load-module module-remap-sink sink_name=remap_FL master=$master channels=1 master_channel_map=front-left channel_map=front-left
+pactl load-module module-combine-sink sink_name='"AYANEO AIR Fixed Phase Audio"' sink_properties=device.description='"AYANEO_AIR_Fixed_Phase_Audio"' slaves=remap_FL,remap_FR channels=2
+EOF
+
+chmod 0755 ${CUSTDIR}
+### Reboot the device to activate, or execute ${CUSTDIR}/audio-phase-fix.sh
+```
+
+### Known Issues
+
+* The display does not always turn on when powering the device on or switching to desktop mode.  Putting it to sleep and waking it up again will resolve it.

--- a/docs/devices/ayaneo/ayaneo-2.md
+++ b/docs/devices/ayaneo/ayaneo-2.md
@@ -1,0 +1,51 @@
+title: AYANEO 2S
+
+<style>
+  code {white-space: nowrap;}
+  kbd {white-space: nowrap;}
+  no-wrap {white-space: nowrap;}
+</style>
+
+# AYANEO 2
+
+![](../../_inc/images/devices/ayaneo-2s.png){ .off-glb }
+
+!!! warning
+    This device is currently unsponsored.
+    Information may be out of date or incorrect.
+
+## Features
+
+| Feature | Notes |
+| -- | -- |
+| <no-wrap>:material-harddisk: Storage</no-wrap> | SteamFork can be run from an SD Card, USB Drive or installed directly to the internal NVME.
+| <no-wrap>:material-wifi: Wifi</no-wrap> | Can be turned on in Steam OS under `Main Menu` > `Network Settings`. |
+| <no-wrap>:simple-bluetooth: Bluetooth</no-wrap> | Supports bluetooth audio and controllers. |
+| <no-wrap>:material-fan: Fan</no-wrap> | Managed automatically. |
+| <no-wrap>:material-lightning-bolt-circle: TDP Limit</no-wrap> | Can be set globally, per system or per game. Requires the [SimpleDeckyTDP](https://github.com/SteamFork/SimpleDeckyTDP) plugin.|
+| <no-wrap>:material-vibrate: Rumble</no-wrap> | Enables the device rumble motor in emulators that support it. |
+| <no-wrap>:material-lightbulb-on: RGB</no-wrap> | Disabled on startup. Requires the [HueSync](https://github.com/honjow/HueSync) plugin for additional RGB control.|
+
+### Function Buttons
+
+| Button | Function |
+| -- | -- |
+| ++"Aya"++ | <kbd>:material-microsoft-xbox: Guide</kbd> <no-wrap>(`Steam Menu`)</no-wrap> |
+| <kbd>:material-equal:</kbd> | <no-wrap><kbd>:material-microsoft-xbox: Guide</kbd> + <kbd>:material-gamepad-circle-down: A</kbd></no-wrap> <no-wrap>(`Quick Access Menu`)</no-wrap> |
+| ++"LC"++ | ++"L4"++ |
+| ++"RC"++ | ++"R4"++ |
+
+## Notes
+
+### Installation
+
+Download the latest `AMD64` version of SteamFork from the button below and follow the instructions listed on the [Install](../../../play/install/) page.
+
+[![Latest Version](https://img.shields.io/github/release/SteamFork/distribution.svg?labelColor=111111&color=5998FF&label=Latest&style=flat#only-light)](https://github.com/SteamFork/distribution/releases/latest)
+[![Latest Version](https://img.shields.io/github/release/SteamFork/distribution.svg?labelColor=dddddd&color=5998FF&label=Latest&style=flat#only-dark)](https://github.com/SteamFork/distribution/releases/latest)
+
+### Booting from an external drive (USB or SD Card)
+
+To boot SteamFork from an external drive, hold <no-wrap>++"LC"++ + <kbd>:material-plus: Volume Up</kbd></no-wrap> and press <kbd>:material-power: Power</kbd> ,
+continue holding <no-wrap>++"LC"++ + <kbd>:material-plus: Volume Up</kbd></no-wrap> until the Ayaneo logo appears.
+Select the storage device with SteamFork from the boot menu using the ++"Aya"++ button, and then press <kbd>:material-plus: Volume Up</kbd> to boot the distribution.

--- a/docs/devices/ayaneo/slide.md
+++ b/docs/devices/ayaneo/slide.md
@@ -1,0 +1,60 @@
+title: AYANEO Slide
+
+<style>
+  code {white-space: nowrap;}
+  kbd {white-space: nowrap;}
+  no-wrap {white-space: nowrap;}
+</style>
+
+# AYANEO Slide
+
+![](../../_inc/images/devices/ayaneo-slide.png){ .off-glb }
+
+!!! warning
+    This device is currently unsponsored.
+    Information may be out of date or incorrect.
+
+!!!info
+    New AMD 7000 series devices do not support S3 sleep and must be configured for Modern Standby + s0i3.
+    Follow the [process on the Wiki](https://wiki.steamfork.org/troubleshooting/#enabling-modern-sleep-on-7000-series-amd-based-devices) to configure your device.
+
+## Features
+
+| Feature | Notes |
+| -- | -- |
+| <no-wrap>:material-harddisk: Storage</no-wrap> | SteamFork can be run from a USB Drive or installed directly to the internal NVME. 
+| <no-wrap>:material-wifi: Wifi</no-wrap> | Can be turned on in Steam OS under `Main Menu` > `Network Settings`. |
+| <no-wrap>:simple-bluetooth: Bluetooth</no-wrap> | Supports bluetooth audio and controllers. |
+| <no-wrap>:material-fan: Fan</no-wrap> | Controlled by system firmware. |
+| <no-wrap>:material-lightning-bolt-circle: TDP Limit</no-wrap> | Can be set globally, per system or per game. Requires the [SimpleDeckyTDP](https://github.com/SteamFork/SimpleDeckyTDP) plugin.|
+| <no-wrap>:material-vibrate: Rumble</no-wrap> | Enables the device rumble motor in emulators that support it. |
+| <no-wrap>:material-lightbulb-on: RGB</no-wrap> | Disabled on startup. Requires the [HueSync](https://github.com/honjow/HueSync) plugin for additional RGB control.|
+
+### Function Buttons
+
+| Button | Function |
+| -- | -- |
+| ++"Aya"++ | <kbd>:material-microsoft-xbox: Guide</kbd> <no-wrap>(`Steam Menu`)</no-wrap> |
+| <kbd>:material-equal:</kbd> | <no-wrap><kbd>:material-microsoft-xbox: Guide</kbd> + <kbd>:material-gamepad-circle-down: A</kbd></no-wrap> <no-wrap>(`Quick Access Menu`)</no-wrap> |
+| ++"LC"++ | ++"L4"++ |
+| ++"RC"++ | ++"R4"++ |
+
+## Notes
+
+### Installation
+
+Download the latest `AMD64` version of SteamFork from the button below and follow the instructions listed on the [Install](../../../play/install/) page.
+
+[![Latest Version](https://img.shields.io/github/release/SteamFork/distribution.svg?labelColor=111111&color=5998FF&label=Latest&style=flat#only-light)](https://github.com/SteamFork/distribution/releases/latest)
+[![Latest Version](https://img.shields.io/github/release/SteamFork/distribution.svg?labelColor=dddddd&color=5998FF&label=Latest&style=flat#only-dark)](https://github.com/SteamFork/distribution/releases/latest)
+
+### Known Issues
+
+* An unknown issue exists that causes the device to reboot unexpectedly.  There is no notification or panic log.
+* When Modern Standby is enabled, the power button does not send events to the OS.  Sleep works with Modern Standby + Si02 when selected from the Steam interface.
+
+### Booting from an external drive (USB or SD Card)
+
+To boot SteamFork from an external drive, hold <no-wrap>++"LC"++ + <kbd>:material-plus: Volume Up</kbd></no-wrap> and press <kbd>:material-power: Power</kbd> ,
+continue holding <no-wrap>++"LC"++ + <kbd>:material-plus: Volume Up</kbd></no-wrap> until the Ayaneo logo appears.
+Select the storage device with SteamFork from the boot menu using the ++"Ayaneo"++ button, and then press <kbd>:material-plus: Volume Up</kbd> to boot the distribution.

--- a/docs/devices/ayn/loki-zero.md
+++ b/docs/devices/ayn/loki-zero.md
@@ -1,0 +1,36 @@
+# Loki Zero
+
+![](../../_inc/images/devices/ayn-loki.png){ .off-glb }
+
+!!! warning
+    This device is currently unsponsored.
+    Information may be out of date or incorrect.
+
+## Features
+
+| Feature&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Notes |
+| -- | -- |
+| :material-harddisk: Storage | SteamFork can be run from an SD Card, USB Drive or installed directly to the internal NVME. |
+| :material-wifi: Wifi | Can be turned on in Steam OS under Main Menu > Network Settings. |
+| :simple-bluetooth: Bluetooth | Supports bluetooth audio and controllers. |
+| :material-fan: Fan | Managed automatically. |
+| :material-lightning-bolt-circle: TDP Limit | Can be set globally, per system or per game. Requires the [SimpleDeckyTDP](https://github.com/SteamFork/SimpleDeckyTDP) plugin.|
+| :material-vibrate: Rumble | Enables the device rumble motor in emulators that support it. |
+| :material-lightbulb-on: RGB |Disabled on startup. Requires the [HueSync](https://github.com/honjow/HueSync) plugin for additional RGB control.|
+
+## Notes
+
+### Installation
+
+Download the latest `AMD64` version of SteamFork from the button below and follow the instructions listed on the [Install](../../../play/install/) page.
+
+[![Latest Version](https://img.shields.io/github/release/SteamFork/distribution.svg?labelColor=111111&color=5998FF&label=Latest&style=flat#only-light)](https://github.com/SteamFork/distribution/releases/latest)
+[![Latest Version](https://img.shields.io/github/release/SteamFork/distribution.svg?labelColor=dddddd&color=5998FF&label=Latest&style=flat#only-dark)](https://github.com/SteamFork/distribution/releases/latest)
+
+### Booting from an external drive (USB or SD Card)
+
+In order to launch SteamFork from an external drive you will need to first change the boot order in the BIOS.  
+
+During boot you can enter the bios by either (1) holding the ++"Home"+"LCC (Turbo)"++ buttons that sit bellow the dpad and right analog stick OR (2) connecting an external keyboard and pressing the ++del++ key.  
+
+In the bios; navigate to the `Boot` menu and then change the boot order to prioritize the SD card or USB Drive under `Boot Order Priorities`. Then go `Save & Exit` and select the Save Changes and Exit option.  This change will persist through all reboots.  If you want to boot into Windows simply remove the SD Card or USB drive.

--- a/docs/devices/index.md
+++ b/docs/devices/index.md
@@ -8,7 +8,7 @@ SteamFork has been tested (i.e. booted at least once) on the list of devices bel
 
 | Manufacturer | Product | Sponsor <sup>1</sup> |
 | -- | -- | -- |
-| Anbernic | [Win600](anbernic/win600) | [uejji](https://github.com/uejji) |
+| Anbernic | [Win600](anbernic/win600) | Community Verified |
 | ANTEC | Core HS <sup>2</sup> | Community Verified |
 | ASUS | [ROG Ally / Ally X](asus/rog-ally) | [flukejones](https://github.com/flukejones) |
 | Atari | VCS | Community Verified |
@@ -26,7 +26,7 @@ SteamFork has been tested (i.e. booted at least once) on the list of devices bel
 | GPD | [Win 4 (AMD 6800U)](gpd/win4-6800u) | [anthonycaccese](https://github.com/anthonycaccese) |
 | GPD | Win 4 (AMD 7840U) | Community Verified by [Maeiourk](https://github.com/maeiourk) |
 | GPD | Win Mini | Community Verified |
-| MSI | [Claw A1M](msi/claw-a1m) <sup>4</sup> | [uejji](https://github.com/uejji) |
+| MSI | [Claw A1M](msi/claw-a1m) | Community Verified |
 
 !!! info
     1. Sponsored devices are fully supported by its maintainer.  Support for unsponsored and community verified devices may vary.

--- a/docs/devices/index.md
+++ b/docs/devices/index.md
@@ -9,20 +9,20 @@ SteamFork has been tested (i.e. booted at least once) on the list of devices bel
 | Manufacturer | Product | Sponsor <sup>1</sup> |
 | -- | -- | -- |
 | Anbernic | [Win600](anbernic/win600) | Community Verified |
-| ANTEC | Core HS <sup>2</sup> | Community Verified |
+| ANTEC | [Core HS](antec/core-hs.md) <sup>2</sup> | Community Verified |
 | ASUS | [ROG Ally / Ally X](asus/rog-ally) | [flukejones](https://github.com/flukejones) |
-| Atari | VCS | Community Verified |
-| AYANEO | 2 | Community Verified |
+| Atari | [VCS](atari/vcs.md) | Community Verified |
+| AYANEO | [2](ayaneo/ayaneo-2) | Community Verified |
 | AYANEO | [2S](ayaneo/ayaneo-2s) <sup>3</sup> | [Fewtarius](https://github.com/fewtarius) |
-| AYANEO | Air / Air Pro | Community Verified |
+| AYANEO | [Air / Air Pro](ayaneo/air.md) | Community Verified |
 | AYANEO | [Air 1S](ayaneo/air-1s) <sup>3</sup> | [winghugs](https://github.com/winghugs) |
 | AYANEO | [Air Plus (AMD 6800U)](ayaneo/air-plus-6800u) | [uejji](https://github.com/uejji) |
 | AYANEO | [Flip KB](ayaneo/flip-kb) <sup>2</sup> | [Fewtarius](https://github.com/fewtarius) |
 | AYANEO | Geek | Community Verified by [alexapple79](https://www.youtube.com/watch?v=4iBE-PUC_0Y) |
 | AYANEO | Next, Next Lite, Next Pro | Community Verified |
-| AYANEO | Slide <sup>2</sup> | Community Verified |
+| AYANEO | [Slide](ayaneo/slide.md) <sup>2</sup> | Community Verified |
 | AYN | [Loki Max](ayn/loki-max) | [Fewtarius](https://github.com/fewtarius) |
-| AYN | Loki Zero | Community Verified |
+| AYN | [Loki Zero](ayn/loki-zero) | Community Verified |
 | GPD | [Win 4 (AMD 6800U)](gpd/win4-6800u) | [anthonycaccese](https://github.com/anthonycaccese) |
 | GPD | Win 4 (AMD 7840U) | Community Verified by [Maeiourk](https://github.com/maeiourk) |
 | GPD | Win Mini | Community Verified |

--- a/docs/devices/msi/claw-a1m.md
+++ b/docs/devices/msi/claw-a1m.md
@@ -11,8 +11,8 @@ title: MSI Claw A1M
 ![](../../_inc/images/devices/msi-claw.png){ .off-glb }
 
 !!! warning
-    Support for this device is still a work in progress. Expect bugs or incomplete/missing features as support is being added.
-    Refer to the [Known Issues](#known-issues) section for more information.
+    This device is currently unsponsored.
+    Information may be out of date or incorrect.
 
 ## Features
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,8 +79,6 @@ nav:
       - Quirks: contribute/quirks.md
     - Devices:
       - devices/index.md
-      - Anbernic:
-        - Win600: devices/anbernic/win600.md
       - ASUS:
         - ROG Ally / Ally X: devices/asus/rog-ally.md
       - AYANEO:
@@ -92,5 +90,3 @@ nav:
         - Loki Max: devices/ayn/loki-max.md
       - GPD:
         - Win 4 (AMD 6800U): devices/gpd/win4-6800u.md
-      - MSI:
-        - Claw A1M: devices/msi/claw-a1m.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,7 +77,7 @@ nav:
       - Code of Conduct: contribute/code-of-conduct.md
       - Build: contribute/build.md
       - Quirks: contribute/quirks.md
-    - Devices:
+    - Sponsored Devices:
       - devices/index.md
       - ASUS:
         - ROG Ally / Ally X: devices/asus/rog-ally.md


### PR DESCRIPTION
While we had decided to remove the wiki pages for unsponsored devices previously, these pages often contained esoteric information that is still useful to users.  These pages can be restored but specifically marked as unsponsored to warn users that some information may be out of date or inaccurate.